### PR TITLE
websocket.erl: Remove gratuitous call to rand:seed/1

### DIFF
--- a/src/lib/websocket.erl
+++ b/src/lib/websocket.erl
@@ -131,7 +131,6 @@ decode(Data) ->
 %%% Internal functions
 %%%===================================================================
 gen_accept_key() ->
-    rand:seed(erlang:now()),
     Key = crypto:strong_rand_bytes(16),
     KeyStr = base64:encode_to_string(Key),
     Accept = binary:list_to_bin(KeyStr ++ "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"),


### PR DESCRIPTION
crypto:strong_rand_bytes/1 doesn't need seeding:

"Generates N bytes randomly uniform 0..255, and returns the result in a binary. Uses a cryptographically secure prng seeded and periodically mixed with operating system provided entropy. By default this is the RAND_bytes method from OpenSSL."

https://www.erlang.org/docs/25/man/crypto#strong_rand_bytes-1